### PR TITLE
Sync build.format with trailing_slash config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,4 +53,7 @@ export default defineConfig({
     },
     extendDefaultPlugins: true,
   },
+  build: {
+    format: config.site.trailing_slash ? 'directory' : 'file'
+  },
 });


### PR DESCRIPTION
Hi 👋 

I have had some problems when deploying a project with Astroplate in Cloudflare Pages due to this configuration.

Apparently there are some known issues regarding the differences between generating pages as single files or as directories with an index.html inside, depending on the hosting provider. [1]

Additionally, in Astro's own documentation, It is recommended to synchronize `build.format` with the `trailingSlash` option to avoid inconsistencies between the development environment and build time. [2]

# Before the changes

For example, the blog page is generated as `/blog/index.html`.

# After the changes

The same page is generated as `/blog.html`.

# References
* [1] https://github.com/slorber/trailing-slash-guide
* [2] https://docs.astro.build/en/reference/configuration-reference/#buildformat