### PR TITLE
Fix Breadcrumbs for single pages

### DIFF
--- a/src/layouts/components/Breadcrumbs.astro
+++ b/src/layouts/components/Breadcrumbs.astro
@@ -16,7 +16,7 @@ paths.forEach((label: string, i: number) => {
   const href = `/${paths.slice(0, i + 1).join("/")}`;
   label !== "page" &&
     parts.push({
-      label: humanize(label.replace(/[-_]/g, " ")) || "",
+      label: humanize(label.replace(".html", "").replace(/[-_]/g, " ")) || "",
       href,
       "aria-label": Astro.url.pathname === href ? "page" : undefined,
     });


### PR DESCRIPTION
This change is related to the change I have proposed in https://github.com/zeon-studio/astroplate/pull/14.

When using the option to generate single pages, this navigation component does not render correctly.

I'm opening a separate PR because I understand that this could be fixed even if the previous one didn't seem appropriate.

# Before the changes

The component renders as: `Home / Blog.Html`

# After the changes

The component renders as expected: `Home / Blog`

Thanks.