### PR TITLE
chore: configure Dockerfile to serve the project as a static site

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  server {
+    listen 80;
+    server_name   _;
+
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    error_page 404 /404.html;
+    location = /404.html {
+            root /usr/share/nginx/html;
+            internal;
+    }
+
+    location / {
+            try_files $uri ${uri}.html $uri/index.html =404;
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,19 @@ npm run build
 
 ```bash
 docker build -t astroplate .
-docker run -p 3000:3000 astroplate
+# or
+# docker --build-arg=npm build -t astroplate .
+# or
+# docker --build-arg=pnpm build -t astroplate .
+docker run -p 3000:80 astroplate
+# or
+# docker run --rm -p 3000:80 astroplate
+```
+
+To access the shell within the container:
+
+```bash
+docker run -it --rm astroplate ash
 ```
 
 <!-- reporting issue -->


### PR DESCRIPTION
Modifies the Dockerfile to serve the project as a static site via nginx.
Based on the example from https://docs.astro.build/en/recipes/docker/#nginx

Closes: #8 