### PR TITLE
20240824 target inline and block code

### DIFF
--- a/src/layouts/PostSingle.astro
+++ b/src/layouts/PostSingle.astro
@@ -74,7 +74,7 @@ const { title, description, author, categories, image, date, tags } = post.data;
             {dateFormat(date)}
           </li>
         </ul>
-        <div class="content mb-10">
+        <div class="content mb-10 prose prose-inline-code:p-[.2em_.4em] prose-inline-code:before:content-none prose-inline-code:after:content-none prose-inline-code:margin-0 prose-inline-code:text-[85%] prose-inline-code:whitespace-break-spaces prose-inline-code:rounded-md prose-inline-code:bg-[rgba(175,184,193,0.2)] prose-inline-code:text-inherit prose-inline-code:font-medium">
           <Content />
         </div>
         <div class="row items-start justify-between">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const theme = require("./src/config/theme.json");
+const plugin = require("tailwindcss/plugin");
 
 let font_base = Number(theme.fonts.font_size.base.replace("px", ""));
 let font_scale = Number(theme.fonts.font_size.scale);
@@ -89,6 +90,12 @@ module.exports = {
         4: "1.5rem",
         5: "3rem",
       },
+    }),
+    plugin(function ({ addVariant }) {
+      addVariant(
+        "prose-inline-code",
+        '&.prose :where(:not(pre)>code):not(:where([class~="not-prose"] *))',
+      );
     }),
   ],
 };


### PR DESCRIPTION
## Before
![Screenshot from 2024-08-24 10-21-20](https://github.com/user-attachments/assets/8db23aff-91c6-4707-ac0e-b57608bd161d)
## After
![Screenshot from 2024-08-24 10-43-09](https://github.com/user-attachments/assets/6abef1f5-4753-48a2-b86d-76cf0da19291)


[Tailwind Typography cannot currently distinguish between inline and block code](https://aaronfrancis.com/2023/targeting-only-inline-code-elements-with-tailwind-typography-3b5e8d43).

There is also [a PR open to get this plugin into upstream typography](https://github.com/tailwindlabs/tailwindcss-typography/issues/329), so adding it like will probably not required at some point

What is kind of annoying is that in astro [Class-based modifiers do not work with @apply directives](https://docs.astro.build/en/guides/integrations-guide/tailwind/#class-based-modifiers-do-not-work-with-apply-directives)

That means that you cannot just add `@apply prose-inline-code:p-[.2em_.4em]` to the `src/styles/components.scss`, but have to put the styles inline. That's what the astro documentation recommends anyway, [but it does not look great](https://github.com/imochorg/astroplate/commit/6074cd525f7456eb123df74faefcbd86d9442574)

Can you think of a better solution here?