### PR TITLE
fix(nav): enable menu expansion and click support on mobile

### DIFF
--- a/src/layouts/partials/Header.astro
+++ b/src/layouts/partials/Header.astro
@@ -55,7 +55,13 @@ const { pathname } = Astro.url;
           <>
             {menu.hasChildren ? (
               <li class="nav-item nav-dropdown group relative">
-                <span
+                <input
+                  type="checkbox"
+                  id={`submenu-${menu.name}`}
+                  class="peer hidden lg:hidden"
+                />
+                <label
+                  for={`submenu-${menu.name}`}
                   class={`nav-link inline-flex items-center ${
                     menu.children?.map(({ url }) => url).includes(pathname) ||
                     menu.children
@@ -69,8 +75,8 @@ const { pathname } = Astro.url;
                   <svg class="h-4 w-4 fill-current" viewBox="0 0 20 20">
                     <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
                   </svg>
-                </span>
-                <ul class="nav-dropdown-list hidden group-hover:block lg:invisible lg:absolute lg:block lg:opacity-0 lg:group-hover:visible lg:group-hover:opacity-100">
+                </label>
+                <ul class=" hidden peer-checked:block lg:invisible lg:absolute lg:block lg:opacity-0 lg:group-hover:visible lg:group-hover:opacity-100">
                   {menu.children?.map((child) => (
                     <li class="nav-dropdown-item">
                       <a


### PR DESCRIPTION
## 📄 Description  
Resolved an issue where the navigation submenu  could not be expanded or clicked on mobile devices.  
This fix ensures the menu is fully interactive and accessible across all breakpoints.  

---

## 📝 Change summary  
- Fixed event handling for mobile nav menu  
- Updated styles to ensure expand/collapse works on smaller screens  
- Improved accessibility for mobile interactions  

---

## 📝 Types of changes  
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] 🚨 Breaking change  
- [ ] ✨ New feature  
- [ ] ⏫ Version upgrade  
- [ ] 🧹 Refactor  
- [ ] 📝 Documentation  

---

## 🧪 How to test  
1. Open the app in mobile view (responsive dev tools or real device)  
2. Tap on the **Page** menu item  
3. Verify that the menu expands and allows interaction with its items  
4. Collapse and expand multiple times to ensure stability  

---

## 📸 Screenshots  

### Before  
<img width="402" height="631" alt="image" src="https://github.com/user-attachments/assets/377f11b4-7495-4dd1-9979-e6856b009320" />

### After  
<img width="460" height="838" alt="image" src="https://github.com/user-attachments/assets/27653088-dad9-4dd6-9576-e9d2dbfc5178" /> 

---