### PR TITLE
fix: position footer at bottom of the page layout

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,7 @@ const { title, description, meta_title, image } = about.data;
   description={description}
   image={image}
 >
-  <section class="section-sm">
+  <section class="section-sm min-h-[calc(100vh-311px)]">
     <div class="container">
       <div class="row justify-center">
         <div class="text-center md:col-10 lg:col-7">


### PR DESCRIPTION
## 📄 Description  
Fixed the **footer positioning** to ensure it always stays at the bottom of the page, even when content is short.  
Applied `min-h-[calc(100vh-311px)]`, subtracting the combined height of the **navbar** and **footer** for accurate layout behavior.  
You can see an example of the fix on the **About** page.  

---

## 📝 Change summary  
- Applied `min-h-[calc(100vh-311px)]` to maintain footer at the bottom of the viewport  
- Adjusted layout structure to properly calculate available content height  
- Verified consistent footer behavior across desktop and mobile views  
- Example available on `/about`  

---

## 📝 Types of changes  
- [ ] 🐛 Bug fix  
- [ ] 🚨 Breaking change  
- [x] 🧹 Chore (layout adjustment / visual fix)  
- [ ] ✨ New feature  
- [ ] ⏫ Version upgrade  
- [ ] 📝 Documentation  

---

## 🧪 How to test  
1. Visit the **About** page (`/about`)  
2. Scroll through pages with short and long content  
3. Verify that the **footer remains at the bottom** of the viewport  
4. Check both **desktop** and **mobile** views  

---

## 📸 Screenshots  

### Before  
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/d851cf0e-ef02-4aec-a34e-a2a30f26b173" />

### After  
<img width="1920" height="922" alt="image" src="https://github.com/user-attachments/assets/e121368c-4475-47b2-81f9-697a66b3c64e" />

---