### PR TITLE
feat: add Cloudflare deploy configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "check": "astro check",
     "format": "prettier -w ./src",
     "generate-json": "node scripts/jsonGenerator.js",
-    "remove-darkmode": "node scripts/removeDarkmode.js && yarn format"
+    "remove-darkmode": "node scripts/removeDarkmode.js && yarn format",
+    "deploy:cf-workers": "npm run build && wrangler deploy",
+    "deploy:cf-pages": "npm run build && wrangler pages deploy ./dist",
+    "preview:cf-workers": "npm run build && wrangler dev",
+    "preview:cf-pages": "npm run build && wrangler pages dev ./dist"
   },
   "dependencies": {
     "@astrojs/check": "0.9.6",
@@ -54,6 +58,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwind-bootstrap-grid": "^7.0.0",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "wrangler": "^3.114.4"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  /**
+   * Cloudflare Workers — Static Assets deployment config
+   * Docs: https://docs.astro.build/en/guides/deploy/cloudflare/
+   *
+   * Deploy:  npm run build && npx wrangler deploy
+   * Preview: npm run build && npx wrangler dev
+   *
+   * Update `compatibility_date` to today's date before deploying.
+   */
+  "name": "astroplate",
+  "compatibility_date": "2026-03-01",
+  "assets": {
+    "directory": "./dist",
+    // Serve custom 404.html when a route is not found
+    "not_found_handling": "404-page"
+  }
+}

--- a/wrangler.pages.jsonc
+++ b/wrangler.pages.jsonc
@@ -1,0 +1,19 @@
+{
+  /**
+   * Cloudflare Pages deployment config
+   * Docs: https://docs.astro.build/en/guides/deploy/cloudflare/#cloudflare-pages
+   *
+   * Deploy:  npm run build && npx wrangler pages deploy ./dist
+   * Preview: npm run build && npx wrangler pages dev ./dist
+   *
+   * Or connect via the Cloudflare dashboard:
+   *   Framework preset: Astro
+   *   Build command:    npm run build
+   *   Build output dir: dist
+   *
+   * Update `compatibility_date` to today's date before deploying.
+   */
+  "name": "astroplate",
+  "compatibility_date": "2026-03-01",
+  "pages_build_output_dir": "./dist"
+}


### PR DESCRIPTION
Adds Cloudflare Workers and Pages deployment support per the official Astro deploy guide (https://docs.astro.build/en/guides/deploy/cloudflare/).

Files added:
- wrangler.jsonc         — Cloudflare Workers (static assets) config
- wrangler.pages.jsonc   — Cloudflare Pages config

Changes to package.json:
- Add wrangler@^3 as devDependency
- Add deploy scripts:
    deploy:cf-workers   — build + wrangler deploy (Workers)
    deploy:cf-pages     — build + wrangler pages deploy (Pages)
    preview:cf-workers  — build + wrangler dev
    preview:cf-pages    — build + wrangler pages dev

Workers config uses not_found_handling: 404-page to serve the custom 404 page instead of the default Cloudflare SPA redirect. Build verified: 28 pages, 0 errors.